### PR TITLE
Create #1897_Redistribute_Characters_to_Make_All_Strings_Equal.py

### DIFF
--- a/#1897_Redistribute_Characters_to_Make_All_Strings_Equal.py
+++ b/#1897_Redistribute_Characters_to_Make_All_Strings_Equal.py
@@ -1,0 +1,18 @@
+class Solution(object):
+    def makeEqual(self, words):
+        """
+        :type words: List[str]
+        :rtype: bool
+        """
+        _dict = {}
+        for word in words:
+            for char in word:
+                if char not in _dict:
+                    _dict[char] = 1
+                else:
+                    _dict[char] += 1
+        n = len(words)
+        for key, value in _dict.items():
+            if value%n != 0:
+                return False
+        return True


### PR DESCRIPTION
需要能够平均分。然而对于词库的单字构造字典，collections.Counter并不好用。
不过我发现直接join一把速度更差。